### PR TITLE
Unlock fileset after ingest, missing EAD warning and PID objnr restriction removed

### DIFF
--- a/flows/flow14/ingest_ead/run.sh
+++ b/flows/flow14/ingest_ead/run.sh
@@ -119,21 +119,21 @@ fi
 #-----------------------------------------------------------------------------------------------------------------------
 eadFile=$fileSet/$archiveID.xml
 if [ ! -f $eadFile ] ; then
-    exit_error "Unable to find the EAD document at $eadFile The ingest was interrupted."
-fi
-
-archiveIDs=$fs_parent/.work/$archiveID/validate/archiveIDs.xml
-if [ ! -f $archiveIDs ] ; then
-    exit_error "Unable to find the archiveIDs file at $archiveIDs The ingest was interrupted."
-fi
-
-ead=$work/$archiveID.xml
-groovy ${DIGCOLPROC_HOME}util/ead.groovy "$eadFile" "$archiveIDs" $ead >> $log
-if [ -f $ead ] ; then
-    echo "See the EAD with added daoloc elements at" >> $log
-    $ead >> $log
+    echo "Warning: Unable to find the EAD document at $eadFile" >> $log
 else
-    exit_error "Unable to add daoloc elements to $ead"
+    archiveIDs=$fs_parent/.work/$archiveID/validate/archiveIDs.xml
+    if [ ! -f $archiveIDs ] ; then
+        exit_error "Unable to find the archiveIDs file at $archiveIDs The ingest was interrupted."
+    fi
+
+    ead=$work/$archiveID.xml
+    groovy ${DIGCOLPROC_HOME}util/ead.groovy "$eadFile" "$archiveIDs" $ead >> $log
+    if [ -f $ead ] ; then
+        echo "See the EAD with added daoloc elements at" >> $log
+        $ead >> $log
+    else
+        exit_error "Unable to add daoloc elements to $ead"
+    fi
 fi
 
 

--- a/flows/flow14/validate/run.sh
+++ b/flows/flow14/validate/run.sh
@@ -86,27 +86,26 @@ cp $fileSet/$archiveID.csv $cf
 #-----------------------------------------------------------------------------------------------------------------------
 eadFile=$fileSet/$archiveID.xml
 if [ ! -f $eadFile ] ; then
-    chown -R "$orgOwner:$orgGroup" $fileSet
-    exit_error "Unable to find the EAD document at $eadFile The validation was interrupted."
-fi
-
-archiveIDs=$work/archiveIDs.xml
-echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?><list>" > $archiveIDs
-while read line
-do
-    IFS=, read objnr ID <<< "$line"
-    echo "<item>$ID</item>" >> $archiveIDs
-done < <(python ${DIGCOLPROC_HOME}/util/concordance_to_list.py --concordance "$cf")
-echo "</list>" >> $archiveIDs
-
-eadReport=$work/ead.report.html
-groovy ${DIGCOLPROC_HOME}util/ead.groovy "$eadFile" "$archiveIDs" $eadReport >> $log
-if [ -f $eadReport ] ; then
-    echo "See the EAD validation for inventarisnummer and unitid matches at" >> $log
-    echo $eadReport >> $log
+    echo "Warning: Unable to find the EAD document at $eadFile" >> $log
 else
-    chown -R "$orgOwner:$orgGroup" $fileSet
-    exit_error "Unable to validate $eadFile"
+    archiveIDs=$work/archiveIDs.xml
+    echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?><list>" > $archiveIDs
+    while read line
+    do
+        IFS=, read objnr ID <<< "$line"
+        echo "<item>$ID</item>" >> $archiveIDs
+    done < <(python ${DIGCOLPROC_HOME}/util/concordance_to_list.py --concordance "$cf")
+    echo "</list>" >> $archiveIDs
+
+    eadReport=$work/ead.report.html
+    groovy ${DIGCOLPROC_HOME}util/ead.groovy "$eadFile" "$archiveIDs" $eadReport >> $log
+    if [ -f $eadReport ] ; then
+        echo "See the EAD validation for inventarisnummer and unitid matches at" >> $log
+        echo $eadReport >> $log
+    else
+        chown -R "$orgOwner:$orgGroup" $fileSet
+        exit_error "Unable to validate $eadFile"
+    fi
 fi
 
 


### PR DESCRIPTION
- Unlock the fileset after ingest, also in case of errors
- Make sure that a missing EAD is a warning, not an error
- Remove the requirement that only an objnr PID is registered in case of multiple files
